### PR TITLE
Set verible/release download's architecture to x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: chipsalliance/verible-format-action@main
+    - uses: chipsalliance/verible-formatter-action@main
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-You can provide the ``files`` argument to point to files to format.
-To search recursively for ``*.v`` and ``*.sv`` files, you can use the ``globstar`` option.
+You can specify the files to format by setting the ``files`` argument to a whitespace-separated list of file patterns.
+The patterns are [unix-like globs](https://en.wikipedia.org/wiki/Glob_(programming)#Unix-like) with support for ** (bash's "globstar").
+To recursively search for ``*.v`` and ``*.sv`` files in the `my_design` folder, you can set `files` to ``'my_design/**/*.{v,sv}'``
 
-By default ``files`` has the value ``'./**/*.{v,sv}'``.
+By default ``files`` has the value ``'./**/*.{v,sv}'``. This searches for all ``*.v`` and ``*.sv`` files in the repository.
 
 ```yaml
 - uses: chipsalliance/verible-formatter-action@main
@@ -43,7 +44,7 @@ By default ``files`` has the value ``'./**/*.{v,sv}'``.
     github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-Additionally, you can add various flags to the formatter with the ``parameter`` input:
+Additionally, you can add various flags to the formatter with the ``parameters`` input:
 
 ```yaml
 - uses: chipsalliance/verible-formatter-action@main

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The GitHub Token input is used to provide
 access to the PR.
 
 Here's a basic example to format all ``*.v`` and ``*.sv`` files:
+
 ```yaml
 name: Verible formatter example
 on:
@@ -27,16 +28,32 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-You can provide ``paths`` argument to point files to format.
-Directories will be searched recursively for ``*.v`` and ``*.sv`` files.
-``paths`` defaults to ``'.'``.
+You can provide the ``files`` argument to point to files to format.
+To search recursively for ``*.v`` and ``*.sv`` files, you can use the ``globstar`` option.
+
+By default ``files`` has the value ``'./**/*.{v,sv}'``.
 
 ```yaml
 - uses: chipsalliance/verible-formatter-action@main
   with:
-    paths: |
-      ./rtl
-      ./shared
+    files:
+      ./rtl/my_file.sv
+      ./rtl/module/*.sv
+      ./testbench/**/*.{v,sv}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Additionally, you can add various flags to the formatter with the ``parameter`` input:
+
+```yaml
+- uses: chipsalliance/verible-formatter-action@main
+  with:
+    files:
+      ./design/**/*.{v,sv}
+    parameters:
+      --indentation_spaces 4
+      --module_net_variable_alignment=preserve
+      --case_items_alignment=preserve
     github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Directories will be searched recursively for ``*.v`` and ``*.sv`` files.
 ``paths`` defaults to ``'.'``.
 
 ```yaml
-- uses: chipsalliance/verible-format-action@main
+- uses: chipsalliance/verible-formatter-action@main
   with:
     paths: |
       ./rtl

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,8 @@ runs:
       shell: bash
     - run: sudo apt install -y python3 wget python3-click golang-go
       shell: bash
-    - run: mkdir verible && curl -s https://api.github.com/repos/chipsalliance/verible/releases/latest | jq '.assets[] | select(.browser_download_url | contains("Ubuntu-20.04")).browser_download_url' | xargs wget -qO- | tar -zxvf - -C verible --strip-components=1
+
+    - run: mkdir verible && curl -s https://api.github.com/repos/chipsalliance/verible/releases/latest | jq '.assets[] | select(.browser_download_url | test("(?=.*Ubuntu-20.04)(?=.*x86_64)")).browser_download_url' | xargs wget -qO- | tar -zxvf - -C verible --strip-components=1
       shell: bash
     - run:  for i in $PWD/verible/bin/*; do sudo ln -s $i /bin/$(basename $i); done
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'verible-formatter'
 description: 'This action formats Verilog/SystemVerilog code'
 author: 'Antmicro'
 inputs:
+  parameters:
+    description: 'Additional parameters to set flags for formatting'
+    required: false
+    default: ''
   paths:
     description: 'Optional array of paths to directories with source code to format'
     required: false
@@ -49,7 +53,7 @@ runs:
             export OVERRIDE_GITHUB_EVENT_PATH=`pwd`/event.json
         fi
 
-        verible-verilog-format --inplace ${{ inputs.paths }} > /dev/null 2>&1
+        verible-verilog-format --inplace ${{ inputs.parameters }} ${{ inputs.paths }} > /dev/null 2>&1
         rm -rf verible
         tmp_file=$(mktemp)
         git diff >"${tmp_file}"

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   paths:
     description: 'Optional array of paths to directories with source code to format'
     required: false
-    default: '.'
+    default: './**/*.{v,sv}'
   github_token:
     description: 'GITHUB_TOKEN'
     default: ''
@@ -53,6 +53,7 @@ runs:
             export OVERRIDE_GITHUB_EVENT_PATH=`pwd`/event.json
         fi
 
+        shopt -s globstar nullglob
         verible-verilog-format --inplace ${{ inputs.parameters }} ${{ inputs.paths }} > /dev/null 2>&1
         rm -rf verible
         tmp_file=$(mktemp)

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: 'Additional parameters to set flags for formatting'
     required: false
     default: ''
-  paths:
-    description: 'Optional array of paths to directories with source code to format'
+  files:
+    description: 'Optional array of files with source code to format'
     required: false
     default: './**/*.{v,sv}'
   github_token:
@@ -54,7 +54,7 @@ runs:
         fi
 
         shopt -s globstar nullglob
-        verible-verilog-format --inplace ${{ inputs.parameters }} ${{ inputs.paths }} > /dev/null 2>&1
+        verible-verilog-format --inplace ${{ inputs.parameters }} ${{ inputs.files }} > /dev/null 2>&1
         rm -rf verible
         tmp_file=$(mktemp)
         git diff >"${tmp_file}"

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'This action formats Verilog/SystemVerilog code'
 author: 'Antmicro'
 inputs:
   parameters:
-    description: 'Additional parameters to set flags for formatting'
+    description: 'Additional parameters passed to formatter executable'
     required: false
     default: ''
   files:

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
     - run: sudo apt install -y python3 wget python3-click golang-go
       shell: bash
-    - run: mkdir verible && curl -s https://api.github.com/repos/chipsalliance/verible/releases/latest | grep browser_download_url | grep Ubuntu-20.04 | cut -f4 -d\" | xargs wget -qO- | tar -zxvf - -C verible --strip-components=1
+    - run: mkdir verible && curl -s https://api.github.com/repos/chipsalliance/verible/releases/latest | jq '.assets[] | select(.browser_download_url | contains("Ubuntu-20.04")).browser_download_url' | xargs wget -qO- | tar -zxvf - -C verible --strip-components=1
       shell: bash
     - run:  for i in $PWD/verible/bin/*; do sudo ln -s $i /bin/$(basename $i); done
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
     - run: sudo apt install -y python3 wget python3-click golang-go
       shell: bash
-    - run: mkdir verible && wget -qO- https://github.com/google/verible/releases/download/v0.0-1213-g9e5c085/verible-v0.0-1213-g9e5c085-Ubuntu-20.04-focal-x86_64.tar.gz | tar -zxvf - -C verible --strip-components=1
+    - run: mkdir verible && curl -s https://api.github.com/repos/chipsalliance/verible/releases/latest | grep browser_download_url | grep Ubuntu-20.04 | cut -f4 -d\" | xargs wget -qO- | tar -zxvf - -C verible --strip-components=1
       shell: bash
     - run:  for i in $PWD/verible/bin/*; do sudo ln -s $i /bin/$(basename $i); done
       shell: bash


### PR DESCRIPTION
This PR
 - updates the antmicro fork to current version of chipsalliance main
 - adds a fix to verible/release search path to select x84_64 architecure
 